### PR TITLE
Add tailwind plugin bugs metadata

### DIFF
--- a/packages/tailwind-plugin/package.json
+++ b/packages/tailwind-plugin/package.json
@@ -27,6 +27,9 @@
     "type": "git",
     "directory": "packages/tailwind-plugin"
   },
+  "bugs": {
+    "url": "https://github.com/rtdui/rtdui/issues"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"


### PR DESCRIPTION
## Summary

- add `bugs.url` metadata for `@rtdui/tailwind-plugin`
- point npm users to the repository issue tracker
- leave runtime code, dependencies, exports, and package files unchanged

## Verification

```sh
node - <<'NODE'
const fs = require('fs');
const p = JSON.parse(fs.readFileSync('packages/tailwind-plugin/package.json', 'utf8'));
if (p.bugs?.url !== 'https://github.com/rtdui/rtdui/issues') throw new Error('missing bugs.url');
console.log(JSON.stringify({ name: p.name, homepage: p.homepage, bugs: p.bugs }, null, 2));
NODE

git diff --check
(cd packages/tailwind-plugin && npm pack --dry-run --ignore-scripts --json)
```

Note: npm currently publishes `@rtdui/tailwind-plugin@6.0.0`, while this repository checkout's package manifest is `5.1.0`. This PR only adds missing npm metadata to the current source manifest so a future publish can expose the issue tracker link.
