### PR TITLE
Add bugs metadata to published packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,9 @@
   "author": "fu zhong wei <jackyleefzw@163.com>",
   "license": "MIT",
   "homepage": "https://rtdui.com/",
+  "bugs": {
+    "url": "https://github.com/rtdui/rtdui/issues"
+  },
   "repository": {
     "url": "https://github.com/rtdui/rtdui.git",
     "type": "git",

--- a/packages/datatable/package.json
+++ b/packages/datatable/package.json
@@ -37,6 +37,9 @@
   "author": "fu zhong wei <jackyleefzw@163.com>",
   "license": "MIT",
   "homepage": "https://rtdui.com/",
+  "bugs": {
+    "url": "https://github.com/rtdui/rtdui/issues"
+  },
   "repository": {
     "url": "https://github.com/rtdui/rtdui.git",
     "type": "git",

--- a/packages/dates/package.json
+++ b/packages/dates/package.json
@@ -32,6 +32,9 @@
   "author": "fu zhong wei <jackyleefzw@163.com>",
   "license": "MIT",
   "homepage": "https://rtdui.com/",
+  "bugs": {
+    "url": "https://github.com/rtdui/rtdui/issues"
+  },
   "sideEffects": [
     "*.css"
   ],

--- a/packages/dialogs/package.json
+++ b/packages/dialogs/package.json
@@ -40,6 +40,9 @@
     "type": "git",
     "directory": "packages/dialogs"
   },
+  "bugs": {
+    "url": "https://github.com/rtdui/rtdui/issues"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -38,6 +38,9 @@
   "author": "fu zhong wei <jackyleefzw@163.com>",
   "license": "MIT",
   "homepage": "https://rtdui.com/",
+  "bugs": {
+    "url": "https://github.com/rtdui/rtdui/issues"
+  },
   "repository": {
     "url": "https://github.com/rtdui/rtdui.git",
     "type": "git",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -39,6 +39,9 @@
     "type": "git",
     "directory": "packages/hooks"
   },
+  "bugs": {
+    "url": "https://github.com/rtdui/rtdui/issues"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/md-editor/package.json
+++ b/packages/md-editor/package.json
@@ -37,6 +37,9 @@
     "type": "git",
     "directory": "packages/md-editor"
   },
+  "bugs": {
+    "url": "https://github.com/rtdui/rtdui/issues"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -35,6 +35,9 @@
   "author": "fu zhong wei <jackyleefzw@163.com>",
   "license": "MIT",
   "homepage": "https://rtdui.com/",
+  "bugs": {
+    "url": "https://github.com/rtdui/rtdui/issues"
+  },
   "repository": {
     "url": "https://github.com/rtdui/rtdui.git",
     "type": "git",

--- a/packages/qr-code/package.json
+++ b/packages/qr-code/package.json
@@ -34,6 +34,9 @@
   "author": "fu zhong wei <jackyleefzw@163.com>",
   "license": "MIT",
   "homepage": "https://rtdui.com/",
+  "bugs": {
+    "url": "https://github.com/rtdui/rtdui/issues"
+  },
   "repository": {
     "url": "https://github.com/rtdui/rtdui.git",
     "type": "git",

--- a/packages/shiki-highlight/package.json
+++ b/packages/shiki-highlight/package.json
@@ -29,6 +29,9 @@
   "author": "fu zhong wei <jackyleefzw@163.com>",
   "license": "MIT",
   "homepage": "https://rtdui.com/",
+  "bugs": {
+    "url": "https://github.com/rtdui/rtdui/issues"
+  },
   "sideEffects": [
     "*.css"
   ],

--- a/packages/signature-pad/package.json
+++ b/packages/signature-pad/package.json
@@ -27,6 +27,9 @@
   "author": "fu zhong wei <jackyleefzw@163.com>",
   "license": "MIT",
   "homepage": "https://rtdui.com/",
+  "bugs": {
+    "url": "https://github.com/rtdui/rtdui/issues"
+  },
   "sideEffects": [
     "*.css"
   ],

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -25,6 +25,9 @@
   "author": "fu zhong wei <jackyleefzw@163.com>",
   "license": "MIT",
   "homepage": "https://rtdui.com/",
+  "bugs": {
+    "url": "https://github.com/rtdui/rtdui/issues"
+  },
   "repository": {
     "url": "https://github.com/rtdui/rtdui.git",
     "type": "git",


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for twelve published `@rtdui/*` packages
- point package consumers to the repository issue tracker
- leave runtime code, dependencies, exports, package files, and versions unchanged

Touched packages:
- `@rtdui/editor`
- `@rtdui/datatable`
- `@rtdui/qr-code`
- `@rtdui/notifications`
- `@rtdui/shiki-highlight`
- `@rtdui/core`
- `@rtdui/spotlight`
- `@rtdui/dates`
- `@rtdui/signature-pad`
- `@rtdui/dialogs`
- `@rtdui/hooks`
- `@rtdui/md-editor`

## Verification
- `node` manifest assertion for all twelve package manifests
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` in each touched package